### PR TITLE
fix superfluous leading zeros

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -118,11 +118,13 @@ func readTagAndLength(conn *bufio.Reader, bytes *[]byte) (ret ldap.TagAndLength,
 			}
 			ret.Length <<= 8
 			ret.Length |= int(b)
-			if ret.Length == 0 {
-				// DER requires that lengths be minimal.
-				err = ldap.StructuralError{"superfluous leading zeros in length"}
-				return
-			}
+			// Compat some lib which use go-ldap or someone else,
+			// they encode int may have leading zeros when it's greater then 127
+			// if ret.Length == 0 {
+			// 	// DER requires that lengths be minimal.
+			// 	err = ldap.StructuralError{"superfluous leading zeros in length"}
+			// 	return
+			// }
 		}
 	}
 


### PR DESCRIPTION
Compat some lib which use go-ldap or someone else, they encode int may have leading zeros when it's greater then 127