### PR TITLE
Shutdown is not terminating

### DIFF
--- a/server.go
+++ b/server.go
@@ -91,7 +91,7 @@ func (s *Server) serve() error {
 			rw.SetWriteDeadline(time.Now().Add(s.WriteTimeout))
 		}
 		if nil != err {
-			if opErr, ok := err.(*net.OpError); ok && opErr.Timeout() {
+			if opErr, ok := err.(*net.OpError); ok || opErr.Timeout() {
 				continue
 			}
 			Logger.Println(err)


### PR DESCRIPTION
When serverLdap.Stop(), the connection is not closed. Thus a proper shutdown can be done with:

```
serverLdap.Stop()
serverLdap.Listener.Close()
```
However, when the goroutine is waiting in s.Listener.Accept, and a shutdown is initiated with serverLdap.Stop() and followed by a serverLdap.Listener.Close(), the s.Listener.Accept returns an connection closed error, which is not a timeout. By changing to || in this statement, a close will go into the select/case statement and properly terminate.