### PR TITLE
Quirky bind authentication workaround

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,18 +10,19 @@ import (
 )
 
 type client struct {
-	Numero      int
-	srv         *Server
-	rwc         net.Conn
-	br          *bufio.Reader
-	bw          *bufio.Writer
-	chanOut     chan *ldap.LDAPMessage
-	wg          sync.WaitGroup
-	closing     chan bool
-	requestList map[int]*Message
-	mutex       sync.Mutex
-	writeDone   chan bool
-	rawData     []byte
+	Numero        int
+	Authenticated bool
+	srv           *Server
+	rwc           net.Conn
+	br            *bufio.Reader
+	bw            *bufio.Writer
+	chanOut       chan *ldap.LDAPMessage
+	wg            sync.WaitGroup
+	closing       chan bool
+	requestList   map[int]*Message
+	mutex         sync.Mutex
+	writeDone     chan bool
+	rawData       []byte
 }
 
 func (c *client) GetConn() net.Conn {


### PR DESCRIPTION
I had the same problem like gojuukaze in issue #29.

I'm pretty sure that we're simply not smart enough to understand how to save the state between the Bind handle and a possible search handle, but to get my actual problem solved I worked around via this "client.Authenticated" member.
With this I'm able to save the bind result within my Bind handler, for later usage within my Search handler.

For sure, this is more or less dirty but may be someone can give us an advice how to make it better.