### PR TITLE
Replace panic with error

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -86,7 +86,8 @@ func readTagAndLength(conn *bufio.Reader, bytes *[]byte) (ret ldap.TagAndLength,
 	//	}
 	// We are expecting the LDAP sequence tag 0x30 as first byte
 	if b != 0x30 {
-		panic(fmt.Sprintf("Expecting 0x30 as first byte, but got %#x instead", b))
+		err = ldap.SyntaxError{fmt.Sprintf("expecting 0x30 as first byte, but got %#x instead", b)}
+		return
 	}
 
 	b, err = readBytes(conn, bytes, 1)


### PR DESCRIPTION
The library should never panic. Return an error instead.