### PR TITLE
Race condition when closing both server and client at the same time

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,11 @@ func (c *client) serve() {
 
 				m := ldap.NewLDAPMessageWithProtocolOp(r)
 
-				c.chanOut <- m
+				select {
+					case <-c.chanOut:
+					default:
+						c.chanOut <- m
+				}
 				c.wg.Done()
 				c.rwc.SetReadDeadline(time.Now().Add(time.Millisecond))
 				return


### PR DESCRIPTION
We had a weird issue with test not working from time to time, turns out there's a race condition if you close both a server and a client at the same time.

Take this example :

```go
ldapClient.Close()
server.Stop()
```

In this case, the goroutine might close the client channel, but receive the server closed message first, meaning that it would try to send to the closed channel.